### PR TITLE
fixed deprecation: QMap => QMultiMap

### DIFF
--- a/dialog.cpp
+++ b/dialog.cpp
@@ -154,7 +154,8 @@ void Dialog::openFolderPath(QString path)
                 cursor.size = imgSubtype;
 
                 QString key = QS("%1").arg(static_cast<int>(subtype), 3, 10, QLatin1Char('0'));
-                cursorFile.cursorMap.insertMulti(key, cursor);
+                cursorFile.cursorMap.insert(key, cursor);
+                
 
                 file.seek(tocPos);
             }

--- a/dialog.h
+++ b/dialog.h
@@ -22,7 +22,7 @@
 
 #include <QImage>
 #include <QList>
-#include <QMap>
+#include <QMultiMap>
 #include <QString>
 #include <QTreeWidgetItem>
 
@@ -42,7 +42,7 @@ struct CursorFile
     QString license;
     QString copyright;
     QString other;
-    QMap<QString, Cursor> cursorMap;
+    QMultiMap<QString, Cursor> cursorMap;
     QString cachedCursors;
 };
 


### PR DESCRIPTION
Compiling `xcursor-viewer` showed a deprecation warning:

```
[ 20%] Automatic MOC and UIC for target xcursor-viewer
[ 20%] Built target xcursor-viewer_autogen
[ 40%] Building CXX object CMakeFiles/xcursor-viewer.dir/xcursor-viewer_autogen/mocs_compilation.cpp.o
[ 60%] Building CXX object CMakeFiles/xcursor-viewer.dir/main.cpp.o
[ 80%] Building CXX object CMakeFiles/xcursor-viewer.dir/dialog.cpp.o
/home/zjeffer/Downloads/xcursor-viewer/dialog.cpp: In member function ‘void Dialog::openFolderPath(QString)’:
/home/zjeffer/Downloads/xcursor-viewer/dialog.cpp:157:49: warning: ‘QMap<K, V>::iterator QMap<K, V>::insertMulti(const Key&, const T&) [with Key = QString; T = Cursor]’ is deprecated: Use QMultiMap for maps storing multiple values with the same key. [-Wdeprecated-declarations]
  157 |                 cursorFile.cursorMap.insertMulti(key, cursor);
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
In file included from /usr/include/qt/QtCore/QMap:1,
                 from /home/zjeffer/Downloads/xcursor-viewer/dialog.h:25,
                 from /home/zjeffer/Downloads/xcursor-viewer/dialog.cpp:19:
/usr/include/qt/QtCore/qmap.h:1366:33: note: declared here
 1366 | typename QMap<Key, T>::iterator QMap<Key, T>::insertMulti(const Key &key, const T &value)
      |                                 ^~~~~~~~~~~~
/home/zjeffer/Downloads/xcursor-viewer/dialog.cpp: In member function ‘void Dialog::showCursor(QTreeWidgetItem*, QTreeWidgetItem*)’:
/home/zjeffer/Downloads/xcursor-viewer/dialog.cpp:293:74: warning: ‘QList<T> QMap<K, V>::values(const Key&) const [with Key = QString; T = Cursor]’ is deprecated: Use QMultiMap for maps storing multiple values with the same key. [-Wdeprecated-declarations]
  293 |             QList<Cursor> cursorList = currentCursorFile.cursorMap.values(key);
      |                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
In file included from /usr/include/qt/QtCore/QMap:1,
                 from /home/zjeffer/Downloads/xcursor-viewer/dialog.h:25,
                 from /home/zjeffer/Downloads/xcursor-viewer/dialog.cpp:19:
/usr/include/qt/QtCore/qmap.h:1360:10: note: declared here
 1360 | QList<T> QMap<Key, T>::values(const Key &key) const
      |          ^~~~~~~~~~~~
[100%] Linking CXX executable xcursor-viewer
[100%] Built target xcursor-viewer
```

This is now fixed.