### PR TITLE
Fix hotspot parsing order

### DIFF
--- a/dialog.cpp
+++ b/dialog.cpp
@@ -138,8 +138,8 @@ void Dialog::openFolderPath(QString path)
                         >> imgVersion
                         >> imgWidth
                         >> imgHeight
-                        >> imgYhot
                         >> imgXhot
+                        >> imgYhot
                         >> imgDelay;
 
                 if (imgHeader != 36 || imgType != type || imgSubtype != subtype || imgVersion != 1) {


### PR DESCRIPTION
Xhot value comes before Yhot value.

Btw, thank you for this utility.